### PR TITLE
Fix server limit for unverified bots

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,9 @@ console.log("https://github.com/net-tech/discord-sus-growth-early-warning")
 		await client.guilds.fetch()
 		const guilds = client.guilds.cache
 
-		if (guilds.size > 75) {
+		if (guilds.size > 100) {
 			spinner.fail(
-				`You are in ${guilds.size} guilds, which is over the 75 limit for non-verified bots. Why are you using this tool if you're already verified?`
+				`You are in ${guilds.size} guilds, which is over the 100 limit for non-verified bots. Why are you using this tool if you're already verified?`
 			)
 			process.exit(0)
 		}


### PR DESCRIPTION
The server limit for unverified bots is 100, not 75. 75 is simply the time Discord will let you apply for verification. Unverified bots can go all the way to 100 before they hit the cap. Is there a different reason the tool is disabled to people with more than 75 servers?